### PR TITLE
Error correction for AXIS definitions

### DIFF
--- a/src/ProjNET/IO/CoordinateSystems/CoordinateSystemWktReader.cs
+++ b/src/ProjNET/IO/CoordinateSystems/CoordinateSystemWktReader.cs
@@ -184,7 +184,6 @@ namespace ProjNet.Converters.WellKnownText
 			tokenizer.NextToken();
 			string unitname = tokenizer.GetStringValue();
 			tokenizer.ReadToken("]");
-			// changed to ToUpper as the individual cases are in UpperCase letters (mw201@bemessung.at, 211115)
 			switch (unitname.ToUpperInvariant())
 			{
 				case "DOWN": return new AxisInfo(axisName, AxisOrientationEnum.Down);

--- a/src/ProjNET/IO/CoordinateSystems/CoordinateSystemWktReader.cs
+++ b/src/ProjNET/IO/CoordinateSystems/CoordinateSystemWktReader.cs
@@ -184,7 +184,8 @@ namespace ProjNet.Converters.WellKnownText
 			tokenizer.NextToken();
 			string unitname = tokenizer.GetStringValue();
 			tokenizer.ReadToken("]");
-			switch (unitname.ToLowerInvariant())
+			// changed to ToUpper as the individual cases are in UpperCase letters (mw201@bemessung.at, 211115)
+			switch (unitname.ToUpperInvariant())
 			{
 				case "DOWN": return new AxisInfo(axisName, AxisOrientationEnum.Down);
 				case "EAST": return new AxisInfo(axisName, AxisOrientationEnum.East);


### PR DESCRIPTION
simple error: lower case / upper case was mixed